### PR TITLE
Do not retry connection when editor is closed

### DIFF
--- a/src/moonlander/library/SocketConnector.java
+++ b/src/moonlander/library/SocketConnector.java
@@ -49,11 +49,10 @@ class SocketConnector extends Connector {
                 greetServer();
                 break;
             } catch (Exception e) {
-                if (i < triesAmount - 1) {
+                if (i < triesAmount - 1 && socket != null) {
                     logger.warning("SocketConnector failed to connect to Rocket. Trying again.");
                     // Close socket if it has been opened already
-                    if (socket != null)
-                        socket.close();
+                    socket.close();
                 } else {
                     logger.warning("SocketConnector failed to connect to Rocket the last time.");
                     close();


### PR DESCRIPTION
An issue was noticed with especially Windows machines, that starting a demo that uses moonlander without rocket editor might take a long while. This is because moonlander tries to make a new connection with the editor 10 times and that time between connection retries varies between machines. The socket that is created will be null if no editor is present. This patch makes moonlander not retry connection if no editor has been detected.

This patch should be tested on a Windows machine before it is accepted.