### PR TITLE
Send SET_ROW to editor as only one byte

### DIFF
--- a/src/moonlander/library/SocketConnector.java
+++ b/src/moonlander/library/SocketConnector.java
@@ -142,7 +142,7 @@ class SocketConnector extends Connector {
         logger.finest("Communicating row="+row+" change to rocket");
 
         try {
-            out.writeInt(Commands.SET_ROW);
+            out.writeByte(Commands.SET_ROW);
             out.writeInt(row);
         } catch (Exception e) {
             logger.severe("Communication with Rocket failed!");


### PR DESCRIPTION
All commands in the rocket protocol are only one byte long. Use
writeByte instead of writeInt for Commands.SET_ROW in
controllerRowChanged(). writeInt sends four bytes of which three are
zeros in this case.

Command processing loop in some known editors appear to a) process
commands byte by byte and b) ignore unknown bytes, so this might not
have affected them, but let's be consistent anyway.