### PR TITLE
readme: fix java.utils typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Shortcut for initializing Moonlander with music playback. This effectively loads
 void Moonlander.changeLogLevel(Level logLevel)
 ```
 
-Change Moonalander´s logging level. All levels from `java.utils.logging.Level` are supported - `Level.FINEST` naturally outputs most data. All logging data is output into stderr (visible on Processing's console).
+Change Moonlander´s logging level. All levels from `java.util.logging.Level` are supported - `Level.FINEST` naturally outputs most data. All logging data is output into stderr (visible on Processing's console).
 
 ```java
 Moonlander.start(String host, int port, String filepath)


### PR DESCRIPTION
Make the full logging.Level type name copypaste friendly. Also Moonlander is spelled wrong. It's leviOsa, not levioSA!

Related background: the following oneliner is very helpful to debug message synchronization between the demo and the editor:

    moonlander.changeLogLevel(java.util.logging.Level.FINEST);

and there are more editors today, which means more debugging.

Our traditional Graffathon debugging this year was from a very old release before commit ca6364d (SET_ROW as byte rather than int) -- the "new" opengl based editor would get confused from spurious bytes in between messages and explode from out of bounds numbers later.